### PR TITLE
feat: completes the suite for image gen tasks

### DIFF
--- a/Forwarders/Task Forwarder.bru
+++ b/Forwarders/Task Forwarder.bru
@@ -13,7 +13,3 @@ get {
 params:path {
   task_forwarder_id: 01968cc3-2f11-c567-772a-03ddbb148341
 }
-
-headers {
-  Authorization: Bearer <token>
-}

--- a/Forwarders/Task Forwarders.bru
+++ b/Forwarders/Task Forwarders.bru
@@ -9,7 +9,3 @@ get {
   body: none
   auth: inherit
 }
-
-headers {
-  Authorization: Bearer <token>
-}

--- a/Forwarders/Update.bru
+++ b/Forwarders/Update.bru
@@ -11,11 +11,7 @@ post {
 }
 
 params:path {
-  task_forwarder_id: 01968cc3-2f11-c567-772a-03ddbb148341
-}
-
-headers {
-  Authorization: Bearer <token>
+  task_forwarder_id: 0196d466-8864-34ff-7eae-d0321c140fb7
 }
 
 body:json {

--- a/Input Processors/Input Processors.bru
+++ b/Input Processors/Input Processors.bru
@@ -9,7 +9,3 @@ get {
   body: none
   auth: inherit
 }
-
-headers {
-  Authorization: Bearer <token>
-}

--- a/Models/LLMs.bru
+++ b/Models/LLMs.bru
@@ -14,14 +14,6 @@ params:query {
   ~include_retired: true
 }
 
-headers {
-  Authorization: Bearer <token>
-}
-
-vars:post-response {
-  imageModelId: 
-}
-
 script:post-response {
   const imageModel = res.getBody().find(model => model.supports_image_output === true);
   if (imageModel) {

--- a/Oauth Clients/Oauth Client.bru
+++ b/Oauth Clients/Oauth Client.bru
@@ -13,7 +13,3 @@ get {
 params:path {
   oauth_client_id: 0196aa23-5d34-c39e-04fb-d086545050bf
 }
-
-headers {
-  Authorization: Bearer <token>
-}

--- a/Oauth Clients/Oauth Clients.bru
+++ b/Oauth Clients/Oauth Clients.bru
@@ -9,7 +9,3 @@ get {
   body: none
   auth: inherit
 }
-
-headers {
-  Authorization: Bearer <token>
-}

--- a/Tags/Create Parent.bru
+++ b/Tags/Create Parent.bru
@@ -1,7 +1,7 @@
 meta {
-  name: Create
+  name: Create Parent
   type: http
-  seq: 3
+  seq: 4
 }
 
 post {
@@ -16,6 +16,11 @@ params:path {
 
 body:json {
   {
-    "name": "staging"
+    "name": "staging",
+    "parent_id": "{{tag_id}}"
   }
+}
+
+vars:pre-request {
+  tag_id: 0196d46a-381a-51fd-6606-789170907ea2
 }

--- a/Tags/Delete.bru
+++ b/Tags/Delete.bru
@@ -1,7 +1,7 @@
 meta {
   name: Delete
   type: http
-  seq: 5
+  seq: 6
 }
 
 delete {
@@ -12,23 +12,5 @@ delete {
 
 params:path {
   tag_id: 
-  entity_type: {{entity_type}}
-}
-
-headers {
-  Authorization: Bearer <token>
-  Content-Type: application/json
-}
-
-body:json {
-  {
-    "name": "staging",
-    "entity_type": "{{entity_type}}",
-    "parent_id": "{{task_id}}"
-  }
-}
-
-vars:pre-request {
-  task_id: 01967c12-c83d-922a-d4ee-09167f06ea51
   entity_type: task
 }

--- a/Tags/Tag.bru
+++ b/Tags/Tag.bru
@@ -11,10 +11,6 @@ get {
 }
 
 params:path {
-  tag_id: 
+  tag_id: 0196d46a-381a-51fd-6606-789170907ea2
   entity_type: task
-}
-
-headers {
-  Authorization: Bearer <token>
 }

--- a/Tags/Tags.bru
+++ b/Tags/Tags.bru
@@ -13,7 +13,3 @@ get {
 params:path {
   entity_type: task
 }
-
-headers {
-  Authorization: Bearer <token>
-}

--- a/Tags/Update.bru
+++ b/Tags/Update.bru
@@ -1,7 +1,7 @@
 meta {
   name: Update
   type: http
-  seq: 4
+  seq: 5
 }
 
 post {
@@ -11,24 +11,12 @@ post {
 }
 
 params:path {
-  tag_id: 
-  entity_type: {{entity_type}}
-}
-
-headers {
-  Authorization: Bearer <token>
-  Content-Type: application/json
+  tag_id: 0196d46a-381a-51fd-6606-789170907ea2
+  entity_type: task
 }
 
 body:json {
   {
-    "name": "staging",
-    "entity_type": "{{entity_type}}",
-    "parent_id": "{{task_id}}"
+    "name": "production"
   }
-}
-
-vars:pre-request {
-  task_id: 01967c12-c83d-922a-d4ee-09167f06ea51
-  entity_type: task
 }

--- a/Tasks/Delete.bru
+++ b/Tasks/Delete.bru
@@ -13,7 +13,3 @@ delete {
 params:path {
   task_id: 
 }
-
-headers {
-  Authorization: Bearer <token>
-}

--- a/Tasks/Image Tasks/Task Create.bru
+++ b/Tasks/Image Tasks/Task Create.bru
@@ -12,7 +12,7 @@ post {
 
 body:json {
   {
-      "name":"Image Generator",
+      "name":"Image Generator v1",
       "enabled":"true",
       "system_prompt":"You are an expert catoonist",
       "user_prompt":"You are an expert cartoonist who specialises in highly detailed coloured pencil sketch style illustrations. Produce a high quality image of {topic}",

--- a/Tasks/Image Tasks/Task Image.bru
+++ b/Tasks/Image Tasks/Task Image.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Task Image
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{api_url}}/task/:task_id/run/:run_id/file/:image_name
+  body: none
+  auth: inherit
+}
+
+params:path {
+  image_name: {{imageName}}
+  run_id: {{runId}}
+  task_id: {{taskId}}
+}
+
+headers {
+  Authorization: Bearer <token>
+}

--- a/Tasks/Image Tasks/Task Run Direct.bru
+++ b/Tasks/Image Tasks/Task Run Direct.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Task Run Direct
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{api_url}}/task/:task_id/run
+  body: json
+  auth: inherit
+}
+
+params:path {
+  task_id: 0196d322-4b44-bb6c-567b-189ee2cf443e
+}
+
+headers {
+  Accept: image/
+}
+
+body:json {
+  {
+    "task_input": {
+      "topic": "a happy alpaca jumping"
+    }
+  }
+}

--- a/Tasks/Image Tasks/Task Run.bru
+++ b/Tasks/Image Tasks/Task Run.bru
@@ -21,3 +21,9 @@ body:json {
     }
   }
 }
+
+script:post-response {
+  bru.setVar('taskId', res.getBody().task_id);
+  bru.setVar('runId', res.getBody().id);
+  bru.setVar('imageName', res.getBody().response.image_name);
+}

--- a/Tasks/Task Detail.bru
+++ b/Tasks/Task Detail.bru
@@ -11,10 +11,6 @@ get {
 }
 
 params:path {
-  task_run_id: 01968709-c79d-bf6f-0ca3-5e00d81f8139
-  task_id: 01967c12-c83d-922a-d4ee-09167f06ea51
-}
-
-headers {
-  Authorization: Bearer <token>
+  task_run_id: 0196d429-05dd-87ee-ddc6-82bbecc3abed
+  task_id: 0196d322-4b44-bb6c-567b-189ee2cf443e
 }

--- a/Tasks/Task Details.bru
+++ b/Tasks/Task Details.bru
@@ -11,9 +11,5 @@ get {
 }
 
 params:path {
-  task_id: 01967c12-c83d-922a-d4ee-09167f06ea51
-}
-
-headers {
-  Authorization: Bearer <token>
+  task_id: 0196d322-4b44-bb6c-567b-189ee2cf443e
 }

--- a/Tasks/Task Run.bru
+++ b/Tasks/Task Run.bru
@@ -11,11 +11,7 @@ post {
 }
 
 params:path {
-  task_id: 01967c12-c83d-922a-d4ee-09167f06ea51
-}
-
-headers {
-  Authorization: Bearer <token>
+  task_id: 0196d322-4b44-bb6c-567b-189ee2cf443e
 }
 
 body:json {

--- a/Tasks/Task.bru
+++ b/Tasks/Task.bru
@@ -11,9 +11,5 @@ get {
 }
 
 params:path {
-  task_id: 01967c12-c83d-922a-d4ee-09167f06ea51
-}
-
-headers {
-  Authorization: Bearer <token>
+  task_id: 0196d322-4b44-bb6c-567b-189ee2cf443e
 }

--- a/Tasks/Tasks.bru
+++ b/Tasks/Tasks.bru
@@ -9,7 +9,3 @@ get {
   body: none
   auth: inherit
 }
-
-headers {
-  Authorization: Bearer <token>
-}

--- a/Tasks/Token Report.bru
+++ b/Tasks/Token Report.bru
@@ -11,9 +11,5 @@ get {
 }
 
 params:path {
-  task_id: 01967c12-c83d-922a-d4ee-09167f06ea51
-}
-
-headers {
-  Authorization: Bearer <token>
+  task_id: 0196d322-4b44-bb6c-567b-189ee2cf443e
 }

--- a/Tasks/Usage Report.bru
+++ b/Tasks/Usage Report.bru
@@ -11,9 +11,5 @@ get {
 }
 
 params:path {
-  task_id: 01967c12-c83d-922a-d4ee-09167f06ea51
-}
-
-headers {
-  Authorization: Bearer <token>
+  task_id: 0196d322-4b44-bb6c-567b-189ee2cf443e
 }


### PR DESCRIPTION
- task runs for image generation
- task run with `Accept: image/` for instant return
- updated `tag` endpoints
- removed headers that weren't required thanks to oauth `inherit`